### PR TITLE
fix(feedback-template-editor): improve feedback template sorting logic

### DIFF
--- a/src/app/common/feedback-template/feedback-template-editor.component.ts
+++ b/src/app/common/feedback-template/feedback-template-editor.component.ts
@@ -33,14 +33,14 @@ import {
   csvResultModalService,
   csvUploadModalService,
 } from 'src/app/ajs-upgraded-providers';
-import {Subscription} from 'rxjs';
-import {COMMA, ENTER} from '@angular/cdk/keycodes';
-import {LiveAnnouncer} from '@angular/cdk/a11y';
-import {MatChipInputEvent} from '@angular/material/chips';
-import {MatAutocompleteSelectedEvent} from '@angular/material/autocomplete';
-import {FileDownloaderService} from '../file-downloader/file-downloader.service';
-import {isEqual} from 'lodash';
-import {NestedCsvDownloadModalService} from './nested-csv-download-modal/nested-csv-download-modal.service';
+import { Subscription } from 'rxjs';
+import { COMMA, ENTER } from '@angular/cdk/keycodes';
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { MatChipInputEvent } from '@angular/material/chips';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { FileDownloaderService } from '../file-downloader/file-downloader.service';
+import { isEqual } from 'lodash';
+import { NestedCsvDownloadModalService } from './nested-csv-download-modal/nested-csv-download-modal.service';
 import API_URL from 'src/app/config/constants/apiURL';
 
 @Component({
@@ -293,35 +293,34 @@ export class FeedbackTemplateEditorComponent
       return 0;
     };
 
-    console.log("Step 1: Initial sorting based on:", sort.active);
-
-    // Step 1: Initial sorting by the chosen method
+    // Initial sorting by the chosen method
     const sortedTemplates = [...this.templateSource.data].sort(compare);
-    console.log("After Initial Sort:", sortedTemplates.map(t => `${t.type}: ${t.chipText} (ID: ${t.id}, Parent: ${t.parentChipId})`));
+    console.log(`After Initial Sort based on: ${sort.active}`, sortedTemplates.map(t => `${t.type}: ${t.chipText}`));
 
-    // Step 2: Determine maximum depth of the hierarchy (only groups contribute to depth)
+    // Determine maximum depth of the hierarchy (only groups contribute to depth)
     const depthMap = new Map<number, number>();
     let maxDepth = 0;
 
-    sortedTemplates.forEach((template) => {
-      if (template.type === 'group') {
-        let depth = 0;
-        let parentId = template.parentChipId;
+    const feedbackGroups = sortedTemplates.filter(t => t.type === 'group');
+    const feedbackTemplates = sortedTemplates.filter(t => t.type !== 'group');
 
-        while (parentId) {
-          depth++;
-          parentId = sortedTemplates.find(t => t.id === parentId)?.parentChipId ?? null;
-        }
 
-        depthMap.set(template.id, depth);
-        maxDepth = Math.max(maxDepth, depth);
+
+    feedbackGroups.forEach((template) => {
+      let depth = 0;
+      let parentId = template.parentChipId;
+
+      while (parentId) {
+        depth++;
+        parentId = sortedTemplates.find(t => t.id === parentId)?.parentChipId ?? null;
       }
+
+      depthMap.set(template.id, depth);
+      maxDepth = Math.max(maxDepth, depth);
     });
 
-    console.log("Maximum Depth:", maxDepth);
-    console.log("Group Depth Mapping:", Array.from(depthMap.entries()));
 
-    // Step 3: Assign sequential order numbers
+    // Assign sequential order numbers
     const orderMap = new Map<number, number>();
     let orderIndex = 1;
 
@@ -329,39 +328,30 @@ export class FeedbackTemplateEditorComponent
       orderMap.set(template.id, orderIndex++);
     });
 
-    console.log("Initial Sequential Order Numbers:", Array.from(orderMap.entries()));
+    feedbackGroups.sort((a, b) => (depthMap.get(a.id)! - depthMap.get(b.id)!));
 
-    // Step 4: Assign hierarchical order to groups **using depth-based multiplier**
-    sortedTemplates.forEach((template) => {
-      if (template.type === 'group') {
-        const parentOrder = template.parentChipId ? orderMap.get(template.parentChipId)! : 0;
-        const depth = depthMap.get(template.id) ?? 0;
-        const multiplier = 10 ** (maxDepth - depth + 1); // Proper scaling based on depth
+    // Assign hierarchical order to groups using depth-based multiplier
+    feedbackGroups.forEach((template) => {
+      const parentOrder = template.parentChipId ? orderMap.get(template.parentChipId)! : 0;
+      const depth = depthMap.get(template.id) ?? 0;
+      const multiplier = 10(maxDepth + 5 - depth * 3); // Proper scaling based on depth
+      let oldOrder = orderMap.get(template.id)!;
 
-        orderMap.set(template.id, parentOrder + orderMap.get(template.id)! * multiplier);
-        console.log(`Group "${template.chipText}" (ID: ${template.id}) -> Computed Order: ${orderMap.get(template.id)}`);
-      }
+      orderMap.set(template.id, parentOrder + orderMap.get(template.id)! * multiplier);
     });
 
-    console.log("Assigned Order for Groups:", Array.from(orderMap.entries()));
+    // Assign order values to templates by directly adding their parent's order
+    feedbackTemplates.forEach((template) => {
+      const parentOrder = orderMap.get(template.parentChipId) ?? 0;
+      orderMap.set(template.id, parentOrder + orderMap.get(template.id)!);
 
-    // Step 5: Assign order values to templates **by directly adding their parent's order**
-    sortedTemplates.forEach((template) => {
-      if (template.type !== 'group') {
-        const parentOrder = orderMap.get(template.parentChipId) ?? 0;
-        orderMap.set(template.id, parentOrder + orderMap.get(template.id)!);
-        console.log(`Template "${template.chipText}" (ID: ${template.id}) -> Computed Order: ${orderMap.get(template.id)}`);
-      }
     });
 
-    console.log("Final Order Assignments:", Array.from(orderMap.entries()));
-
-    // Step 6: Sort again by computed hierarchical order
+    // Sort again by computed hierarchical order
     sortedTemplates.sort((a, b) => (orderMap.get(a.id)! - orderMap.get(b.id)!));
-
     console.log("Final Sorted Order:", sortedTemplates.map(t => `${t.chipText} (Final Order: ${orderMap.get(t.id)})`));
 
-    // Step 7: Update the data source
+    // Update the data source
     this.templateSource.data = [...sortedTemplates];
   }
 


### PR DESCRIPTION
# Description

This pull request improves the sorting logic for feedback templates in the feedback template editor. The new approach separates feedback groups and individual templates early on, optimizes depth calculation, and refines hierarchical ordering using a depth-based multiplier.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The changes have been tested by:
- Sorting feedback templates with various hierarchical structures and ensuring expected order.
- Manually verifying output logs and data consistency.
- Running the application and confirming that UI updates reflect the new sorting behaviour.

## Testing Checklist:

- [ ] ~Tested in latest Chrome~ Say no to spyware!
- [x] Tested in latest Safari
- [x] Tested in latest Firefox

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
